### PR TITLE
ryba/hbase: fixed uid/gid for hadoop-metrics2-hbase.properties file

### DIFF
--- a/hbase/master/install.coffee.md
+++ b/hbase/master/install.coffee.md
@@ -205,6 +205,8 @@ Enable stats collection in Ganglia and Graphite
         content: hbase.metrics.config
         backup: true
         mode: 0o640
+        uid: hbase.user.name
+        gid: hbase.group.name
 
       # @call header: 'SSL', retry: 0, ->
       #   {ssl, ssl_server, ssl_client, hdfs} = @config.ryba

--- a/hbase/regionserver/install.coffee.md
+++ b/hbase/regionserver/install.coffee.md
@@ -184,6 +184,8 @@ Enable stats collection in Ganglia and Graphite
         content: hbase.metrics.config
         backup: true
         mode: 0o0640
+        uid: hbase.user.name
+        gid: hbase.group.name
 
 # User limits
 


### PR DESCRIPTION
Metrics can not start if hbase can not read the property file.

(cc @IDerr :tada: )