### PR TITLE
nifi: check if additional_libs is empty

### DIFF
--- a/nifi/install.coffee.md
+++ b/nifi/install.coffee.md
@@ -333,7 +333,7 @@ By default it is a local file, but in cluster mode, it uses zookeeper.
 
 ## Additional Libs
 
-      @call header: 'Additional Libs', ->
+      @call header: 'Additional Libs', if: nifi.custom_libs_dir.length, ->
         for lib in glob.sync nifi.custom_libs_dir
           @file.download
             target: "/usr/hdf/current/nifi/lib/extras/#{path.basename lib}"


### PR DESCRIPTION
I think we should check if the array `nifi.custom_libs_dir` is empty because `glob` throws an error when it is the case (i.e. when the option is not provided in the configuration):

`TypeError: glob pattern string required`.