### PR TITLE
lib/hdfs_upload lock_file fix

### DIFF
--- a/lib/hdfs_upload.coffee.md
+++ b/lib/hdfs_upload.coffee.md
@@ -61,7 +61,7 @@
             echo 'lock exist, check if valid'
             timeout=240 # 4 minutes
             now=`date '+%s'`
-            crdate=$(hdfs dfs -stat $lock_file | xargs -0 date '+%s' -d)
+            crdate=$((`hdfs dfs -stat "%Y" $lock_file`/1000))
             if [ $(($now - $crdate)) -le $timeout ]; then
               sleep_time=$((240 - $crdate + $now + 5))
               echo crdate $crdate


### PR DESCRIPTION
`hdfs dfs -stat` returns the modification date as UTC date whereas `date '+%s'` returns the number of seconds since epoch, so we are not comparing the same things. This results in a failure because of the lock file check when parallel uploading a file to HDFS on multiple nodes.

I think we need to provide the `"%Y"` parameter which returns the milliseconds, hence the `/1000` to get the result in seconds.

Also is there a specific reason why the lock file is actually a directory ?