### PR TITLE
ranger/admin: add Solr Embedded mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Trunk
 
+* ranger: add Solr Embedded
 * ambari repo: fix
 * ambari: optionnal hdf dependency
 * hdf: rename repo to source

--- a/ranger/admin/configure.coffee.md
+++ b/ranger/admin/configure.coffee.md
@@ -157,6 +157,28 @@ And it is configured by Ryba only in ryba/solr/cloud_docker installation.
 If no `ryba/solr/*` is configured Ranger admin deploys a `ryba/solr/standalone` 
 on the same host than `ryba/ranger/admin` module.
 
+## Example
+
+To use the embedded Solr mode, configure ranger-admin as follows:
+
+```json
+{ "ranger": {
+    "admin": {
+      "solr_type": "embedded"
+    }
+} }
+```
+
+If you have configured a Solr Cloud Docker in your cluster, you can configure like this:
+
+```json
+{ "ranger": {
+    "admin": {
+      "solr_type": "cloud_docker"
+    }
+} }
+```
+
       ranger.admin.solr_type ?= 'cloud_docker'
       solr = {}
       solrs_urls = ''

--- a/ranger/admin/configure.coffee.md
+++ b/ranger/admin/configure.coffee.md
@@ -7,7 +7,7 @@ variables but also inject some function to be executed.
       sc_ctxs = @contexts 'ryba/solr/cloud'
       st_ctxs = @contexts 'ryba/solr/standalone'
       scd_ctxs = @contexts 'ryba/solr/cloud_docker'
-      {ryba} = @config
+      {java, ryba} = @config
       {realm, db_admin, ssl, core_site, hdfs, hadoop_group, hadoop_conf_dir} = ryba
       ranger = @config.ryba.ranger ?= {}
 
@@ -78,7 +78,6 @@ User can be External and Internal. Only Internal users can be created from the r
        throw Error "new passord's length must be > 8, must contain one alpha and numerical character at lest" 
       ranger.admin.conf_dir ?= '/etc/ranger/admin'
       ranger.admin.site ?= {}
-      ranger.admin.site ?= {}
       ranger.admin.site['ranger.service.http.port'] ?= '6080'
       ranger.admin.site['ranger.service.https.port'] ?= '6182'
       ranger.admin.install ?= {}
@@ -128,11 +127,14 @@ Here SOLR configuration is discovered and ranger admin is set up.
 
 Ryba support both Solr Cloud mode and Solr Standalone installation. 
 
-The `ranger.admin.solr_type` designates the type of solr service (ie standalone, cloud, cloud indocker)
+The `ranger.admin.solr_type` designates the type of solr service (ie standalone, embedded, cloud, cloud indocker)
 used for Ranger.
 The type requires differents instructions/configuration for ranger plugin audit to work.
 - Solr Standalone `ryba/solr/standalone`
   Ryba default. You need to set `ryba/solr/standalone` on one host.
+- Solr Standalone embedded
+  No need to have `ryba/solr/standalone` on one host, Solr will be installed on the same host as Ranger Admin.
+  Change property `ranger.admin.solr_type` to `embedded` to use it.
 - Solr Cloud `ryba/solr/cloud`
   Changes  property `ranger.admin.solr_type` to `cloud` and deploy `ryba/solr/cloud`
   module on at least one host.
@@ -182,6 +184,55 @@ on the same host than `ryba/ranger/admin` module.
               caname: "hadoop_root_ca"
             , -> @call 'ryba/ranger/admin/solr_bootstrap'
           break;
+        when 'embedded'
+          solr = @config.ryba.solr ?= {}
+          solr.user ?= {}
+          solr.user = name: solr.user if typeof solr.user is 'string'
+          solr.user.name ?= 'solr'
+          solr.user.home ?= "/var/lib/#{solr.user.name}"
+          solr.user.system ?= true
+          solr.user.comment ?= 'Solr User'
+          solr.user.groups ?= 'hadoop'
+          solr.group ?= {}
+          solr.group = name: solr.group if typeof solr.group is 'string'
+          solr.group.name ?= 'solr'
+          solr.group.system ?= true
+          solr.user.gid ?= solr.group.name
+          solr.version ?= '5.5.2'
+          solr.root_dir ?= '/usr'
+          solr.install_dir ?= "#{solr.root_dir}/solr/#{solr.version}"
+          solr.latest_dir = '/opt/lucidworks-hdpsearch/solr'
+          solr.pid_dir ?= '/var/run/solr'
+          solr.log_dir ?= '/var/log/solr'
+          solr.conf_dir ?= '/etc/solr/conf'
+          solr.env ?= {}
+          solr.dir_factory ?= "${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"
+          solr.lock_type = 'native'
+          solr.conf_source = "#{__dirname}/../resources/solr/solr_5.xml.j2"
+          if @config.ryba.security is 'kerberos'
+            solr.principal ?= "#{solr.user.name}/#{@config.host}@#{realm}"
+            solr.keytab ?= '/etc/security/keytabs/solr.service.keytab'
+          solr.ssl ?= {}
+          solr.ssl.enabled ?= false
+          solr.port ?= if solr.ssl.enabled then 9983 else 8983
+          solr.ssl_trustore_path ?= "#{solr.conf_dir}/trustore"
+          solr.ssl_trustore_pwd ?= 'solr123'
+          solr.ssl_keystore_path ?= "#{solr.conf_dir}/keystore"
+          solr.ssl_keystore_pwd ?= 'solr123'
+          solr.env['SOLR_JAVA_HOME'] ?= java.java_home
+          solr.env['SOLR_HOST'] ?= @config.host
+          solr.env['SOLR_HEAP'] ?= "512m"
+          solr.env['SOLR_PORT'] ?= "#{solr.port}"
+          solr.env['ENABLE_REMOTE_JMX_OPTS'] ?= 'false'
+          if solr.ssl.enabled
+            solr.env['SOLR_SSL_KEY_STORE'] ?= solr.ssl_keystore_path
+            solr.env['SOLR_SSL_KEY_STORE_PASSWORD'] ?= solr.ssl_keystore_pwd
+            solr.env['SOLR_SSL_TRUST_STORE'] ?= solr.ssl_trustore_path
+            solr.env['SOLR_SSL_TRUST_STORE_PASSWORD'] ?= solr.ssl_trustore_pwd
+            solr.env['SOLR_SSL_NEED_CLIENT_AUTH'] ?= 'false'
+          solr.jre_home ?= java.jre_home
+          solrs_urls = "#{if solr.ssl.enabled  then 'https://'  else 'http://'}#{@config.host}:#{@config.ryba.solr.port}/solr/ranger_audits"
+          ranger.admin.install['audit_solr_zookeepers'] ?= 'NONE'
         when 'cloud'
           throw Error 'No Solr Cloud Server configure' unless sc_ctxs.length > 0
           solr_ctx = sc_ctxs[0]

--- a/ranger/admin/index.coffee.md
+++ b/ranger/admin/index.coffee.md
@@ -21,6 +21,7 @@ Ranger permit access
         'ryba/ranger/admin/configure'
       commands:
         'install': [
+          'ryba/ranger/solr/install'
           'ryba/ranger/admin/install'
           'ryba/ranger/admin/start'
           'ryba/ranger/admin/setup'

--- a/ranger/resources/solr/solr.ini.sh.j2
+++ b/ranger/resources/solr/solr.ini.sh.j2
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# By default the script will use JAVA_HOME to determine which java
+# to use, but you can set a specific path for Solr to use without
+# affecting other Java applications on your server/workstation.
+#SOLR_JAVA_HOME=""
+
+# Increase Java Heap as needed to support your indexing / query needs
+SOLR_HEAP="512m"
+
+# Expert: If you want finer control over memory options, specify them directly
+# Comment out SOLR_HEAP if you are using this though, that takes precedence
+#SOLR_JAVA_MEM="-Xms512m -Xmx512m"
+
+# Enable verbose GC logging
+GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+
+# These GC settings have shown to work well for a number of common Solr workloads
+GC_TUNE="-XX:NewRatio=3 \
+-XX:SurvivorRatio=4 \
+-XX:TargetSurvivorRatio=90 \
+-XX:MaxTenuringThreshold=8 \
+-XX:+UseConcMarkSweepGC \
+-XX:+UseParNewGC \
+-XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 \
+-XX:+CMSScavengeBeforeRemark \
+-XX:PretenureSizeThreshold=64m \
+-XX:+UseCMSInitiatingOccupancyOnly \
+-XX:CMSInitiatingOccupancyFraction=50 \
+-XX:CMSMaxAbortablePrecleanTime=6000 \
+-XX:+CMSParallelRemarkEnabled \
+-XX:+ParallelRefProcEnabled"
+
+# Set the ZooKeeper connection string if using an external ZooKeeper ensemble
+# e.g. host1:2181,host2:2181/chroot
+# Leave empty if not using SolrCloud
+#ZK_HOST=""
+
+# Set the ZooKeeper client timeout (for SolrCloud mode)
+#ZK_CLIENT_TIMEOUT="15000"
+
+# By default the start script uses "localhost"; override the hostname here
+# for production SolrCloud environments to control the hostname exposed to cluster state
+#SOLR_HOST="192.168.1.1"
+
+# By default the start script uses UTC; override the timezone if needed
+#SOLR_TIMEZONE="UTC"
+
+# Set to true to activate the JMX RMI connector to allow remote JMX client applications
+# to monitor the JVM hosting Solr; set to "false" to disable that behavior
+# (false is recommended in production environments)
+ENABLE_REMOTE_JMX_OPTS="false"
+
+# The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
+# RMI_PORT=18983
+
+# Set the thread stack size
+SOLR_OPTS="$SOLR_OPTS -Xss256k"
+
+
+# Anything you add to the SOLR_OPTS variable will be included in the java
+# start command line as-is, in ADDITION to other options. If you specify the
+# -a option on start script, those options will be appended as well. Examples:
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.autoSoftCommit.maxTime=3000"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.clustering.enabled=true"
+
+# Location where the bin/solr script will save PID files for running instances
+# If not set, the script will create PID files in $SOLR_TIP/bin
+export SOLR_PID_DIR={{ryba.solr.single.pid_dir}}
+
+# Path to a directory for Solr to store cores and their data. By default, Solr will use server/solr
+# If solr.xml is not stored in ZooKeeper, this directory needs to contain solr.xml
+#SOLR_HOME=
+
+# Solr provides a default Log4J configuration properties file in server/resources
+# however, you may want to customize the log settings and file appender location
+# so you can point the script to use a different log4j.properties file
+#LOG4J_PROPS=/var/solr/log4j.properties
+
+# Location where Solr should write logs to; should agree with the file appender
+# settings in server/resources/log4j.properties
+export SOLR_LOGS_DIR={{ryba.solr.single.log_dir}}
+
+# Sets the port Solr binds to, default is 8983
+#SOLR_PORT=8983
+
+# Uncomment to set SSL-related system properties
+# Be sure to update the paths to the correct keystore for your environment
+#SOLR_SSL_KEY_STORE=etc/solr-ssl.keystore.jks
+#SOLR_SSL_KEY_STORE_PASSWORD=secret
+#SOLR_SSL_TRUST_STORE=etc/solr-ssl.keystore.jks
+#SOLR_SSL_TRUST_STORE_PASSWORD=secret
+#SOLR_SSL_NEED_CLIENT_AUTH=false
+#SOLR_SSL_WANT_CLIENT_AUTH=false
+
+# Uncomment if you want to override previously defined SSL values for HTTP client
+# otherwise keep them commented and the above values will automatically be set for HTTP clients
+#SOLR_SSL_CLIENT_KEY_STORE=
+#SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
+#SOLR_SSL_CLIENT_TRUST_STORE=
+#SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
+
+# Settings for authentication
+#SOLR_AUTHENTICATION_CLIENT_CONFIGURER=
+#SOLR_AUTHENTICATION_OPTS=

--- a/ranger/resources/solr/solr.j2
+++ b/ranger/resources/solr/solr.j2
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### BEGIN INIT INFO
+# Provides:          solr
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Controls Apache Solr as a Service
+### END INIT INFO
+
+# Example of a very simple *nix init script that delegates commands to the bin/solr script
+# Typical usage is to do:
+#
+#   cp bin/init.d/solr /etc/init.d/solr
+#   chmod 755 /etc/init.d/solr
+#   chown root:root /etc/init.d/solr
+#   update-rc.d solr defaults
+#   update-rc.d solr enable
+
+# Where you extracted the Solr distribution bundle
+SOLR_INSTALL_DIR={{ryba.solr.latest_dir}}
+SOLR_CONF_DIR="{{ryba.solr.conf_dir}}"
+SOLR_ENV="{{ryba.solr.conf_dir}}/solr.in.sh"
+RUNAS={{ryba.solr.user.name}}
+
+if [ ! -d "$SOLR_INSTALL_DIR" ]; then
+  echo "$SOLR_INSTALL_DIR not found! Please check the SOLR_INSTALL_DIR setting in your $0 script."
+  exit 1
+fi
+
+# Path to an include file that defines environment specific settings to override default
+# variables used by the bin/solr script. It's highly recommended to define this script so
+# that you can keep the Solr binary files separated from live files (pid, logs, index data, etc)
+# see bin/solr.in.sh for an example
+SOLR_ENV=${SOLR_ENV:-"/usr/solr/default/solr/solr.in.sh"}
+
+if [ ! -f "$SOLR_ENV" ]; then
+  echo "$SOLR_ENV not found! Please check the SOLR_ENV setting in your $0 script."
+  exit 1
+fi
+
+# Specify the user to run Solr as; if not set, then Solr will run as root.
+# Running Solr as root is not recommended for production environments
+RUNAS="solr"
+
+# verify the specified run as user exists
+runas_uid="`id -u "$RUNAS"`"
+if [ $? -ne 0 ]; then
+  echo "User $RUNAS not found! Please create the $RUNAS user before running this script."
+  exit 1
+fi
+
+case "$1" in
+  start|stop|restart|status)
+    SOLR_CMD="$1"
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit
+esac
+
+if [ -n "$RUNAS" ]; then
+  su -c "SOLR_INCLUDE=\"$SOLR_ENV\" \"$SOLR_INSTALL_DIR/bin/solr\" $SOLR_CMD  -s {{ryba.solr.user.home}}" - "$RUNAS"
+else
+  SOLR_INCLUDE="$SOLR_ENV" "$SOLR_INSTALL_DIR/bin/solr  -s {{ryba.solr.user.home}}" "$SOLR_CMD"
+fi

--- a/ranger/resources/solr/solr_5.xml.j2
+++ b/ranger/resources/solr/solr_5.xml.j2
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+   This is an example of a simple "solr.xml" file for configuring one or 
+   more Solr Cores, as well as allowing Cores to be added, removed, and 
+   reloaded via HTTP requests.
+
+   More information about options available in this configuration file, 
+   and Solr Core administration can be found online:
+   http://wiki.apache.org/solr/CoreAdmin
+-->
+
+<solr>
+
+  <solrcloud>
+
+    <str name="host">${host:{{config.host}}}</str>
+    <int name="hostPort">${jetty.port:{{config.ryba.solr.single.port}}}</int>
+    <str name="hostContext">${hostContext:solr}</str>
+
+    <bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool>
+    <str name="zkCredientialsProvider">org.apache.solr.common.cloud.VMParamsSingleSetCredentialsDigestZkCredentialsProvider</str>
+    <str name="zkACLProvider">org.apache.solr.common.cloud.VMParamsAllAndReadonlyDigestZkACLProvider</str>
+    <int name="zkClientTimeout">${zkClientTimeout:30000}</int>
+    <int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:600000}</int>
+    <int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:60000}</int>
+
+  </solrcloud>
+
+  <shardHandlerFactory name="shardHandlerFactory"
+    class="HttpShardHandlerFactory">
+    <int name="socketTimeout">${socketTimeout:600000}</int>
+    <int name="connTimeout">${connTimeout:60000}</int>
+  </shardHandlerFactory>
+
+</solr>

--- a/ranger/resources/solr/solrconfig.xml
+++ b/ranger/resources/solr/solrconfig.xml
@@ -1642,7 +1642,7 @@
   <updateRequestProcessorChain name="add-unknown-fields-to-the-schema">
     <processor class="solr.DefaultValueUpdateProcessorFactory">
         <str name="fieldName">_ttl_</str>
-        <str name="value">{{retention_period}}DAYS</str>
+        <str name="value">+{{retention_period}}DAYS</str>
     </processor>
     <processor class="solr.processor.DocExpirationUpdateProcessorFactory">
         <int name="autoDeletePeriodSeconds">300</int>

--- a/ranger/solr/install.coffee.md
+++ b/ranger/solr/install.coffee.md
@@ -1,0 +1,254 @@
+
+# Solr Install
+
+    module.exports = header: 'Solr Embedded Install', handler: ->
+      {solr, ranger, ssl, realm} = @config.ryba
+      return unless ranger.admin.solr_type is 'embedded'
+      cluster_config = ranger.admin.cluster_config
+      krb5 = @config.krb5_client.admin[realm]
+      protocol = if solr.ssl.enabled then 'https' else 'http'
+
+## Dependencies
+
+      @call 'masson/core/krb5_client/wait'
+      @registry.register ['file', 'jaas'], 'ryba/lib/file_jaas'
+      @registry.register 'hdfs_mkdir', 'ryba/lib/hdfs_mkdir'
+
+## IPTables
+
+| Service      | Port  | Proto       | Parameter          |
+|--------------|-------|-------------|--------------------|
+| Solr Server  | 8983  | http        | port               |
+| Solr Server  | 9983  | https       | port               |
+
+IPTables rules are only inserted if the parameter "iptables.action" is set to
+"start" (default value).
+
+      @tools.iptables
+        header: 'IPTables'
+        rules: [
+          { chain: 'INPUT', jump: 'ACCEPT', dport: solr.port, protocol: 'tcp', state: 'NEW', comment: "Solr Server #{protocol}" }
+        ]
+        if: @config.iptables.action is 'start'
+
+## Identities
+
+      @system.group header: 'Group', solr.group
+      @system.user header: 'User', solr.user
+
+## Layout
+
+      @system.mkdir
+        target: solr.user.home
+        uid: solr.user.name
+        gid: solr.group.name
+      @system.mkdir
+        directory: solr.conf_dir
+        uid: solr.user.name
+        gid: solr.group.name
+
+## Packages
+
+      @call header: 'Packages', ->
+        @service
+          name: 'lucidworks-hdpsearch'
+        @system.chown
+          target: '/opt/lucidworks-hdpsearch'
+          uid: solr.user.name
+          gid: solr.group.name
+
+## Configuration
+
+      @call header: 'Configuration', ->
+        @system.link 
+          source: "#{solr.latest_dir}/conf"
+          target: solr.conf_dir
+        @system.remove
+          shy: true
+          target: "#{solr.latest_dir}/bin/solr.in.sh"
+        @system.link 
+          source: "#{solr.conf_dir}/solr.in.sh"
+          target: "#{solr.latest_dir}/bin/solr.in.sh"
+        @service.init
+          header: 'Init Script'
+          uid: solr.user.name
+          gid: solr.group.name
+          mode: 0o0755
+          source: "#{__dirname}/../resources/solr/solr.j2"
+          target: '/etc/init.d/solr'
+          local: true
+          context: @config
+
+## Layout
+
+      @call header: 'Solr Layout', ->
+        @system.mkdir
+          target: solr.pid_dir
+          uid: solr.user.name
+          gid: solr.group.name
+          mode: 0o0755
+        @system.tmpfs
+          if_os: name: ['redhat','centos'], version: '7'
+          mount: solr.pid_dir
+          uid: solr.user.name
+          gid: solr.group.name
+          perm: '0750'
+        @system.mkdir
+          target: solr.log_dir
+          uid: solr.user.name
+          gid: solr.group.name
+          mode: 0o0755
+        @system.mkdir
+          target: solr.user.home
+          uid: solr.user.name
+          gid: solr.group.name
+          mode: 0o0755
+
+## Config
+
+      @call header: 'Configure', ->
+        solr.env['SOLR_AUTHENTICATION_OPTS'] ?= ''
+        solr.env['SOLR_AUTHENTICATION_OPTS'] += " -D#{k}=#{v} "  for k, v of solr.auth_opts
+        writes = for k,v of solr.env
+          match: RegExp "^.*#{k}=.*$", 'mg'
+          replace: "#{k}=\"#{v}\" # RYBA DON'T OVERWRITE"
+          append: true
+        @file.render
+          header: 'Solr Environment'
+          source: "#{__dirname}/../resources/solr/solr.ini.sh.j2"
+          target: "#{solr.conf_dir}/solr.in.sh"
+          context: @config
+          write: writes
+          local: true
+          backup: true
+          eof: true
+        @file.render
+          header: 'Solr Config'
+          source: solr.conf_source
+          target: "#{solr.conf_dir}/solr.xml"
+          uid: solr.user.name
+          gid: solr.group.name
+          mode: 0o0755
+          context: {
+            host: @config.host
+            port: @config.ryba.solr.port
+          }
+          local: true
+          backup: true
+          eof: true
+        @system.link
+          source: "#{solr.conf_dir}/solr.xml"
+          target: "#{solr.user.home}/solr.xml"
+
+## Kerberos
+
+      @krb5.addprinc krb5,
+        header: 'Solr Server User'
+        principal: solr.principal
+        keytab: solr.keytab
+        randkey: true
+        uid: solr.user.name
+        gid: solr.group.name
+
+## SSL
+
+      @java.keystore_add
+        keystore: solr.ssl_keystore_path
+        storepass: solr.ssl_keystore_pwd
+        caname: "hadoop_root_ca"
+        cacert: "#{ssl.cacert}"
+        key: "#{ssl.key}"
+        cert: "#{ssl.cert}"
+        keypass: solr.ssl_keystore_pwd
+        name: @config.shortname
+        local: true
+      @java.keystore_add
+        keystore: solr.ssl_trustore_path
+        storepass: solr.ssl_keystore_pwd
+        caname: "hadoop_root_ca"
+        cacert: "#{ssl.cacert}"
+        local: true
+
+## Start
+
+      @service.start
+        header: 'Solr Start'
+        name: 'solr'
+
+## Prepare ranger_audits Collection/Core
+
+      @system.mkdir
+        target: "#{solr.user.home}/ranger_audits"
+        uid: solr.user.name
+        gid: solr.group.name
+        mode: 0o0755
+        
+      @call  
+        header: 'Ranger Collection Solr Embedded'
+      , ->
+        @file.download
+          source: "#{__dirname}/../resources/solr/elevate.xml"
+          target: "#{solr.user.home}/ranger_audits/conf/elevate.xml" #remove conf if solr/cloud
+        @file.download
+          source: "#{__dirname}/../resources/solr/managed-schema"
+          target: "#{solr.user.home}/ranger_audits/conf/managed-schema"
+        @file.render
+          source: "#{__dirname}/../resources/solr/solrconfig.xml"
+          target: "#{solr.user.home}/ranger_audits/conf/solrconfig.xml"
+          local: true
+          context:
+            retention_period: ranger.admin.audit_retention_period
+
+## Create ranger_audits Collection/Core
+The solrconfig.xml file corresponding to ranger_audits collection/core is rendered from
+the resources, as it is not distributed in the apache community version.
+The syntax of the command depends also from the solr type installed.
+In solr/standalone core are used, whereas in solr/cloud collections are used.
+We manage creating the ranger_audits core/collection in the three modes.
+
+### Solr Embedded
+
+      @system.execute
+        header: 'Create Ranger Core (embedded)'
+        unless_exec: """
+        curl -k --fail  \"#{if solr.ssl.enabled  then 'https://'  else 'http://'}#{@config.host}:#{@config.ryba.solr.port}/solr/admin/cores?core=ranger_audits&wt=json\" \
+        | grep '\"schema\":\"managed-schema\"'
+         """
+        cmd: """
+        #{solr.latest_dir}/bin/solr create_core -c ranger_audits \
+        -d  #{solr.user.home}/ranger_audits
+        """
+
+## ACL Users & Permissions
+
+      # @call
+      #   header: 'Create Users and Permissions'
+      # , ->
+      #   @call header: 'Create Users', ->
+      #     url = "#{ranger.admin.install['audit_solr_urls'].split(',')[0]}/solr/admin/authentication"
+      #     cmd = 'curl --fail --insecure'
+      #     cmd += " --user #{ranger.admin.solr_admin_user}:#{ranger.admin.solr_admin_password} "
+      #     for user in ranger.admin.solr_users
+      #       @system.execute
+      #         cmd: """
+      #         #{cmd} \
+      #           #{url} -H 'Content-type:application/json' \
+      #           -d '#{JSON.stringify('set-user':"#{user.name}":"#{user.secret}")}'
+      #         """
+      #   @call header: 'Set ACL Users', ->
+      #     url = "#{ranger.admin.install['audit_solr_urls'].split(',')[0]}/solr/admin/authorization"
+      #     cmd = 'curl --fail --insecure'
+      #     cmd += " --user #{ranger.admin.solr_admin_user}:#{ranger.admin.solr_admin_password} "
+      #     for user in cluster_config.ranger.solr_users
+      #       new_role = "#{user.name}": ['read','update','admin']
+      #       @system.execute
+      #         cmd: """
+      #         #{cmd} \
+      #           #{url} -H 'Content-type:application/json' \
+      #           -d '#{JSON.stringify('set-user-role': new_role )}'
+      #         """
+
+## Dependencies
+
+    path = require 'path'
+    mkcmd  = require '../../lib/mkcmd'

--- a/ranger/solr/install.coffee.md
+++ b/ranger/solr/install.coffee.md
@@ -250,5 +250,5 @@ We manage creating the ranger_audits core/collection in the three modes.
 
 ## Dependencies
 
-    path = require 'path'
+    path = require('path').posix
     mkcmd  = require '../../lib/mkcmd'

--- a/ranger/solr/install.coffee.md
+++ b/ranger/solr/install.coffee.md
@@ -219,35 +219,6 @@ We manage creating the ranger_audits core/collection in the three modes.
         -d  #{solr.user.home}/ranger_audits
         """
 
-## ACL Users & Permissions
-
-      # @call
-      #   header: 'Create Users and Permissions'
-      # , ->
-      #   @call header: 'Create Users', ->
-      #     url = "#{ranger.admin.install['audit_solr_urls'].split(',')[0]}/solr/admin/authentication"
-      #     cmd = 'curl --fail --insecure'
-      #     cmd += " --user #{ranger.admin.solr_admin_user}:#{ranger.admin.solr_admin_password} "
-      #     for user in ranger.admin.solr_users
-      #       @system.execute
-      #         cmd: """
-      #         #{cmd} \
-      #           #{url} -H 'Content-type:application/json' \
-      #           -d '#{JSON.stringify('set-user':"#{user.name}":"#{user.secret}")}'
-      #         """
-      #   @call header: 'Set ACL Users', ->
-      #     url = "#{ranger.admin.install['audit_solr_urls'].split(',')[0]}/solr/admin/authorization"
-      #     cmd = 'curl --fail --insecure'
-      #     cmd += " --user #{ranger.admin.solr_admin_user}:#{ranger.admin.solr_admin_password} "
-      #     for user in cluster_config.ranger.solr_users
-      #       new_role = "#{user.name}": ['read','update','admin']
-      #       @system.execute
-      #         cmd: """
-      #         #{cmd} \
-      #           #{url} -H 'Content-type:application/json' \
-      #           -d '#{JSON.stringify('set-user-role': new_role )}'
-      #         """
-
 ## Dependencies
 
     path = require('path').posix


### PR DESCRIPTION
New option `ranger.admin.solr_type: 'embedded'` allows to install and boostrap a Solr instance while installing Ranger on the same host, without needing to have a `solr cloud_docker` or a `solr standalone` in the configuration. It also creates the `ranger_audits` collection.